### PR TITLE
Allow Java Platform to be first in classpath

### DIFF
--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/internal/SynchronizeGradleBuildOperation.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/internal/SynchronizeGradleBuildOperation.java
@@ -213,10 +213,10 @@ final class SynchronizeGradleBuildOperation implements IWorkspaceRunnable {
         //old Gradle versions did not expose natures, so we need to add the Java nature explicitly
         CorePlugin.workspaceOperations().addNature(workspaceProject, JavaCore.NATURE_ID, progress.newChild(1));
         IJavaProject javaProject = JavaCore.create(workspaceProject);
-        GradleClasspathContainer.addIfNotPresent(javaProject, progress.newChild(1));
         ClasspathContainerUpdater.updateFromModel(javaProject, project, this.allProjects, progress.newChild(1));
         WtpClasspathUpdater.update(javaProject, project, progress.newChild(1));
         JavaSourceSettingsUpdater.update(javaProject, project.getJavaSourceSettings().get(), progress.newChild(1));
+        GradleClasspathContainer.addIfNotPresent(javaProject, progress.newChild(1));
         SourceFolderUpdater.update(javaProject, project.getSourceDirectories(), progress.newChild(1));
     }
 


### PR DESCRIPTION
Change order of classpath building to allow java platform to load before external dependencies.
